### PR TITLE
Add jungle_focused color scheme

### DIFF
--- a/jungle_focused.py
+++ b/jungle_focused.py
@@ -1,0 +1,16 @@
+from ranger.colorschemes.default import Default
+from ranger.gui.color import blue, green, red
+
+
+class Scheme(Default):
+    def use(self, context):
+        fg, bg, attr = Default.use(self, context)
+
+        if context.main_column:
+            fg = green
+
+        # Copied from ranger.colorschemes.jungle
+        if context.in_titlebar and context.hostname:
+            fg = red if context.bad else blue
+
+        return fg, bg, attr


### PR DESCRIPTION
I found it hard to navigate when having multiple columns, and the "selection line" having the same color for all of them. Then I though more about it, and noticed that it was because I got used to Finder, which does what this scheme does.